### PR TITLE
Updates graphql-client dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,28 +2,29 @@ PATH
   remote: .
   specs:
     abe_client (1.0.0)
-      graphql-client (>= 0.12.2)
+      graphql-client (>= 0.16.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.4)
+    activesupport (6.1.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    concurrent-ruby (1.0.5)
-    graphql (1.7.8)
-    graphql-client (0.12.2)
-      activesupport (>= 3.0, < 6.0)
-      graphql (~> 1.6)
-    i18n (0.9.1)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    concurrent-ruby (1.1.8)
+    graphql (1.12.3)
+    graphql-client (0.16.0)
+      activesupport (>= 3.0)
+      graphql (~> 1.8)
+    i18n (1.8.7)
       concurrent-ruby (~> 1.0)
-    minitest (5.11.1)
+    minitest (5.14.3)
     rake (12.3.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.4)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
@@ -33,4 +34,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.16.1
+   1.17.2

--- a/abe_client.gemspec
+++ b/abe_client.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |s|
   s.authors       = ["Adam Cooke"]
   s.email         = ["me@adamcooke.io"]
   s.licenses      = ['MIT']
-  s.add_dependency "graphql-client", ">= 0.12.2"
+  s.add_dependency "graphql-client", ">= 0.16.0"
   s.add_development_dependency "rake"
 end


### PR DESCRIPTION
Updating graphql-client dependency to v 1.16.0 to allow rails 6 updates on apps that use abe_client