### PR TITLE
fix: Ensure subscriber query works with ruby keyword args

### DIFF
--- a/lib/abe_client/subscriber.rb
+++ b/lib/abe_client/subscriber.rb
@@ -10,7 +10,7 @@ module AbeClient
     GRAPHQL
 
     def self.add(blog, email_address, first_name = nil, last_name = nil, identity_uid = nil)
-      result = Client.query(AddSubscriberMutation, {
+      result = Client.query(AddSubscriberMutation,
         :variables => {
           :blog => blog,
           :email_address => email_address,
@@ -18,7 +18,7 @@ module AbeClient
           :last_name => last_name,
           :identity_uid => identity_uid
         }
-      })
+      )
 
       if result.data.add_subscriber && result.data.add_subscriber.id
         result.data.add_subscriber


### PR DESCRIPTION
When upgrading codebase-website to Ruby 3.2 I discovered the blog newsletter subscribe functionality didn't work.

Turns out calling this query to subscribe was generating the error: Wrong number of args got 2 expected 1

All the other queries generated in this abe client lib work fine, the difference is the subscriber wrapped it's args in `{ }`. The underlying [graphql-client gem](https://github.com/github/graphql-client/blob/master/lib/graphql/client.rb#L332) expects variables as a keyword arg. By removing the `{ }` it fixes the issue.

I have verified this change is backwards compatible by applying the same fix when running the codebase-website on Ruby 2.7